### PR TITLE
Introduce stale issue cleanup workflow with dry-run enabled

### DIFF
--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write # to label, comment and close issues (aws-actions/stale-issue-cleanup)
      
     runs-on: ubuntu-latest
-    name: Stale issue job
+    name: Stale issues
     steps:
     - uses: aws-actions/stale-issue-cleanup@v6
       with:
@@ -23,9 +23,9 @@ jobs:
         issue-types: issues
         # Setting messages to an empty string will cause the automation to skip
         # that category
-        stale-issue-message: This issue has not received a response in 30 days and will be closed in 7 days. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-issue-message: This issue is missing required information and will be closed in 7 days. To keep the issue open, leave a comment.
         # this has been added as a placeholder but will likely not be used because the timeline is set as 100 years
-        ancient-issue-message: We have noticed this issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+        ancient-issue-message: This issue will automatically close because it has stalled for 1 year. To keep the issue open, leave a comment.
        
         # These labels are required
         stale-issue-label: closing-soon

--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -1,0 +1,53 @@
+name: "Close stale issues"
+
+# Controls when the action will run.
+on:
+  # allows doing a manual trigger of the action
+  workflow_dispatch: 
+  # disable cron until dry run is completed successfully
+  # schedule:
+  # - cron: "0 0 * * *"
+
+permissions: {}
+jobs:
+  cleanup:
+    permissions:
+      issues: write # to label, comment and close issues (aws-actions/stale-issue-cleanup)
+     
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v6
+      with:
+        # Types of issues that will be processed
+        issue-types: issues
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        stale-issue-message: This issue has not received a response in 30 days and will be closed in 7 days. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        # this has been added as a placeholder but will likely not be used because the timeline is set as 100 years
+        ancient-issue-message: We have noticed this issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+       
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-labels: no-autoclose
+        response-requested-label: needs-response
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 30
+        days-before-close: 7
+        # setting this to 100 years to avoid closing valid old issues that are yet to be triaged
+        days-before-ancient: 36500
+
+        # If you don't want to mark an issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 5
+
+        # Leave this alone, or set to a PAT for the action to use
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Testing/debugging options
+        loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: true


### PR DESCRIPTION
## Description
This introduces a GitHub workflow to warn and then close issues marked with a specific label (requiring additional information) without activity after a specified amount of time. 
It leverages the AWS Issue Cleanup GitHub action: https://github.com/aws-actions/stale-issue-cleanup.
Dry run has been set to true to verify the workflow matches expectation. A follow-up PR with disable it once it is verified that it works as expected.

## Motivation and Context
This helps automate the process of managing stale issues.

## License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
