### PR TITLE
Disable dry run for issue cleanup workflow

### DIFF
--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -2,10 +2,10 @@ name: "Close stale issues"
 
 # Controls when the action will run.
 on:
-  # allows doing a manual trigger of the action and running it on a schedule at midnight everyday
+  # allows doing a manual trigger of the action and running it on a schedule at 10am PT  everyday(converted since expression is anchored to UTC)
   workflow_dispatch: 
   schedule:
-   - cron: "0 0 * * *"
+   - cron: "0 17 * * *"
 
 permissions: {}
 jobs:

--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -2,11 +2,10 @@ name: "Close stale issues"
 
 # Controls when the action will run.
 on:
-  # allows doing a manual trigger of the action
+  # allows doing a manual trigger of the action and running it on a schedule at midnight everyday
   workflow_dispatch: 
-  # disable cron until dry run is completed successfully
-  # schedule:
-  # - cron: "0 0 * * *"
+  schedule:
+   - cron: "0 0 * * *"
 
 permissions: {}
 jobs:
@@ -50,4 +49,4 @@ jobs:
         # Testing/debugging options
         loglevel: DEBUG
         # Set dry-run to true to not perform label or close actions.
-        dry-run: true
+        dry-run: false


### PR DESCRIPTION
## Description
Follow-up to PR #342 disabling dry-run after successful verification of changes expected. It also sets up a schedule to run the workflow everyday at 10am PT.

## License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
